### PR TITLE
Update docker-entrypoint.sh add </dev/null

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,4 +32,4 @@ fi
 
 
 # Run samba.
-smbd --foreground --log-stdout
+smbd --foreground --log-stdout </dev/null


### PR DESCRIPTION
The container stops immediately after start, I found that the solution in https://unix.stackexchange.com/questions/277114/docker-container-with-samba-exits-without-any-message helps in this case